### PR TITLE
Fix some typos in the ucode entries.

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -542,7 +542,7 @@
 @end sign
 
 @sign	|A₂.ZA.AN.MUŠ₃|
-@ucode	x12000.x1235D.x1202D.x12239
+@ucode	x12009.x1235D.x1202D.x12239
 @v	aškudₓ
 @end sign
 
@@ -2777,22 +2777,22 @@
 @end sign
 
 @sign	|BI.ZIZ₂|
-@ucode	x12049.x1203E
+@ucode	x12049.x12369
 @v	{kaš}ulušinₓ
 @end sign
 
 @sign	|BI.ZIZ₂.A.AN|
-@ucode	x12049.x1203E.x12000.x1202D
+@ucode	x12049.x12369.x12000.x1202D
 @v	{kaš}ulušin
 @end sign
 
 @sign	|BI.ZIZ₂.AN|
-@ucode	x12049.x1203E.x1202D
+@ucode	x12049.x12369.x1202D
 @v	{kaš}ulušin₃
 @end sign
 
 @sign	|BI.ZIZ₂.AN.NA|
-@ucode	x12049.x1203E.x1202D.x1223E
+@ucode	x12049.x12369.x1202D.x1223E
 @v	{kaš}ulušin₂
 @end sign
 
@@ -3234,7 +3234,7 @@
 @list LAK744
 @uphase	1
 @uname	CUNEIFORM SIGN DAG KISIM5 TIMES GA
-@ucode	x1205C
+@ucode	x1205B
 @v	akan
 @v	akani
 @v	haraₓ
@@ -15899,14 +15899,14 @@
 @end sign
 
 @sign	|LU₂.SU|
-@ucode	x121FB.x122E2
+@ucode	x121FD.x122E2
 @v	šimašgi
 @inote CDLI
 @v	šimaški
 @end sign
 
 @sign	|LU₂.SU.A|
-@ucode	x121FB.x122E2.x12000
+@ucode	x121FD.x122E2.x12000
 @v	šimašgi₂
 @inote CDLI
 @v	šimaški₂
@@ -16347,7 +16347,7 @@
 @end sign
 
 @sign	|LU₃.PAP.PAP|
-@ucode	x12048.x1227D.x1227D
+@ucode	x12216.x1227D.x1227D
 @v	titab₂
 @form	~a |PAP.PAP.LU₃|
 @ucode x1227D.x1227D.x12216
@@ -19398,13 +19398,13 @@
 @end sign
 
 @sign	|PA.DAG.KISIM₅×GUD|
-@ucode	x1227A.x12056
+@ucode	x1227A.x1205F
 @v	udul₁₁
 @v	utul₁₁
 @end sign
 
 @sign	|PA.DAG.KISIM₅×KAK|
-@ucode	x1227A.x12056
+@ucode	x1227A.x12063
 @v	gabar
 @v	kabar
 @v	kapar
@@ -23477,7 +23477,7 @@
 @v	sulgar
 @v	šuhub
 @form ~a	|BAR.3×AN|
-@ucode	x12047.x1202E.x1202D
+@ucode	x12047.x1202F
 @note  The sign |BAR.3×AN| is a third millennium/OB variant of |ŠU₂.3×AN| and is thus not associated with kunga.
 @v-	kungaₓ
 @v	suhub
@@ -23561,7 +23561,7 @@
 @list SLLHA545
 @list KWU503
 @list KWU570
-@ucode	x122D9
+@ucode	x122D9.x12088
 @v	šudul
 @v	šudulu
 @v	šudun
@@ -29148,7 +29148,7 @@
 @end sign
 
 @sign |ŠEŠ.KI.DIM×ŠE|
-@ucode	x12016.x1202D.x122C0.x121A0
+@ucode	x122C0.x121A0.x12075
 @inote epsd2
 @v     munzerₓ
 @end sign
@@ -29189,7 +29189,7 @@
 @end sign
 
 @sign	|UD.MA₂.AB×(U.U.U).ŠIR|
-@ucode	x12313.x12223.x12014.x1230B.None.x122D3
+@ucode	x12313.x12223.x12014.x122D3
 @v	siraraₓ
 @end sign
 
@@ -29658,7 +29658,7 @@
 @end sign
 
 @sign |U.GIŠ%GIŠ|
-@ucode	x1230B.x12263
+@ucode	x1230B.x12112
 @inote epsd2/praxis
 @v     šennurₓ
 @end sign


### PR DESCRIPTION
Found while working on a Sumero-Akkadian cuneiform input method based on this sign list.

Overview of the typos corrected, with links to the epsd2 entries exhibiting them if applicable:
- 𒀉𒍝𒀭𒈹 aškudₓ(A₂.ZA.AN.MUŠ₃) was encoded as *𒀀𒍝𒀭𒈹  *A.ZA.AN.MUŠ₃:
  - http://oracc.org/epsd2/o0024610.
- 𒁉𒍩 <sup>kaš</sup>ulušinₓ(ZIZ₂), 𒁉𒍩𒀀𒀭 <sup>kaš</sup>ulušin(ZIZ₂.A.AN), 𒁉𒍩𒀭𒈾 <sup>kaš</sup>ulušin₂(ZIZ₂.AN.NA), 𒁉𒍩𒀭 <sup>kaš</sup>ulušin₃(ZIZ₂.AN) were encoded with an 𒀾 AŠ₂ instead of a 𒍩 ZIZ₂ (even though ulušin, ulušin₂, and ulušin₃ all use 𒍩).
- 𒁛 akan(DAG.KISIM₅×GA) was encoded as 𒁜 massa(DAG.KISIM₅×(GA.MAŠ)):
  - http://oracc.org/epsd2/o0023817.
- 𒇽𒋢 šimašgi(LU₂.SU) and 𒇽𒋢𒀀 šimašgi₂(LU₂.SU.A) were encoded as *𒇻𒋢 (*LU.SU) and *𒇻𒋢𒀀(*LU.SU.A) respectively:
  - http://oracc.org/epsd2/o0039373.
- 𒈖𒉽𒉽 titab₂(LU₃.PAP.PAP) was encoded as 𒁈𒉽𒉽 titab(BARA₂.PAP.PAP):
  - http://oracc.org/epsd2/o0040424.
- 𒉺𒁟 udul₁₁(PA.DAG.KISIM₅×GUD) was encoded as *𒉺𒁖 *PA.DAG.
- 𒉺𒁣 udul₉(PA.DAG.KISIM₅×KAK) was encoded as *𒉺𒁖 *PA.DAG:
  - http://oracc.org/epsd2/o0041094;
  - also read rig₁₀: http://oracc.org/epsd2/o0037006.
- 𒁇𒀯 suḫub(BAR.3×AN) was encoded as 𒁇𒀮𒀭 BAR.AN&AN.AN, whereas the other two suḫub (ŠU₂.3×AN and 3×AN.BAR) are encoded with a 3×AN:
  - http://oracc.org/epsd2/o0038310.
- 𒋙𒂈 šudul(ŠU₂.DUN₃ _gunû gunû šeššig_) was encoded as 𒋙 ŠU₂ (missing the DUN₄=DUN₃ _gunû gunû šeššig_):
  - http://oracc.org/epsd2/o0039802.
  - Question: should the name of that sign be changed from `|ŠU₂.DUN₃@g@g@s|` to `|ŠU₂.DUN₄|`? The description seems to be a holdover from an ancient version of the encoding proposal, *e.g.*, http://unicode.org/wg2/docs/n2698.pdf proposed `DUN3 GUNU GUNU SHESHIG`, but that became `DUN4`.
- 𒋀𒆠𒁵 munzerₓ(ŠEŠ.KI.DIM×ŠE) was encoded as 𒀖𒀭𒋀𒆠 munzerₓ(AB₂.AN.ŠEŠ.KI):
  - http://oracc.org/epsd2/o0034493.
- 𒌓𒈣𒀔𒋓 siraraₓ(UD.MA₂.AB×(U.U.U).ŠIR) was encoded as *𒌓𒈣𒀔𒌋`None`𒋓 *UD.MA₂.AB×(U.U.U).U.`None`.ŠIR (not sure what happened here):
  - http://oracc.org/epsd2/o0047595.
- 𒌋𒄒 šennurₓ(U.GIŠ%GIŠ) was encoded as *𒌋𒉣 *U.NUN:
  - http://oracc.org/epsd2/o0039173.