### PR TITLE
Encode ŠITA₂ as 𒋖𒄑 rather than 𒂷𒄑

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -23113,7 +23113,7 @@
 
 @sign	ŠITA₂
 @uphase	0
-@ucode	x120B7.x12111
+@ucode x122D6.x12111
 @v	ešda
 @v	gišha
 @v?	ha₈
@@ -23131,10 +23131,6 @@
 @end form
 @form ~b |NI.DIŠ.GIŠ|
 @ucode x1224C.x12079.x12111
-@inote dcclt !sg
-@end form
-@form ~c |ŠITA.GIŠ|
-@ucode x122D6.x12111
 @inote dcclt !sg
 @end form
 @end sign


### PR DESCRIPTION
Another correction to a `@ucode` entry spotted while making my input method, but I am sending this one separately because it is less immediately obvious (at least to my untrained eyes).

I believe that ŠITA₂ ought to be encoded as 𒋖𒄑 ŠITA.GIŠ as its main form (visible, e.g., in http://oracc.org/epsd2/o0039486), instead of that being variant form ~c of a sign whose main form is GA₂.GIŠ, for the following reasons:
- The encoded signs that are described by the MZL as containing a ŠÍTA have SHITA PLUS GISH in their Unicode name and a reference glyph consistent with that description:
  - MZL 128 𒀟 AG×ŠÍTA, Unicode AK TIMES SHITA PLUS GISH;
  - MZL 771 variant 𒇝 LAGAB×ŠÍTA-ERIM, Unicode LAGAB TIMES SHITA PLUS GISH PLUS ERIN2.
- Chapter VII of the MZL gives aB and nB forms for 434 ŠÍTA consistent with 𒋖𒄑 rather than 𒂷𒄑 (cf. the aB and nB forms given in the same chapter for 388 𒋖 and 387  𒂷). While the MZL describes 434 as ŠÍTA (“GÁ-GIŠ”), note that it also describes 388 as ŠÍTA (“GÁ”), whereas they are disunified; note the quotation marks in both cases.
- Every attestation for ŠITA₂ I looked at in CDLI looks like the reference glyphs for 𒋖𒄑 rather than those for 𒂷𒄑:
  - OAkk: https://cdli.ucla.edu/search/search_results.php?SearchMode=Text&ObjectID=P212997, obv. l. 3, https://cdli.ucla.edu/search/search_results.php?SearchMode=Text&ObjectID=P216875 rev. col. 2, ll. 1 (partial) and 9;
  - Lagaš II: https://cdli.ucla.edu/search/search_results.php?SearchMode=Text&ObjectID=P217911 rev. last line, and many others mentioning that same year name. Also https://cdli.ucla.edu/search/search_results.php?SearchMode=Text&ObjectID=P232275 col. 6 ll. 24, 31, & 36.
  - Ur III: https://cdli.ucla.edu/search/search_results.php?SearchMode=Text&ObjectID=P108512 rev. l. 12.
  - OB: https://cdli.ucla.edu/search/search_results.php?SearchMode=Text&ObjectID=P345503 rev. l. 13 in the scribe’s numbering, l. 6 in CDLI’s; contrast the ga₂ ga₂ l. 9/5.

I think the encoding 𒂷𒄑 may simply be a mistake stemming from the NA (or MA?) unification of 𒂷 and 𒋖, instead of corresponding to any real variant of šita₂.