### PR TITLE
Fix the ucode entry for |KASKAL.PA.DU|

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -19461,7 +19461,7 @@
 @end sign
 
 @sign	|KASKAL.PA.DU|
-@ucode	x1227A.x1207A
+@ucode	x1219C.x1227A.x1207A
 @v	maškimₓ
 @end sign
 


### PR DESCRIPTION
Apparently the 𒆜 had lost its way in eca139a23bfbeec4da5a74fa1335a3b86905370b.