### PR TITLE
Rename 𒎊 and 𒍹 and update their @ucode entries

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -6323,8 +6323,8 @@
 @inote dcclt !sg
 @end sign
 
-@sign	|GA₂×AN.KAK.A|
-@ucode	x120BC.x12195.x12000
+@sign	|GA₂×(AN.KAK.A)|
+@ucode	x12379
 @v	usud
 @end sign
 

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -16025,8 +16025,8 @@
 @v	ereₓ
 @end sign
 
-@sign	|LU₂×EŠ₂.LAL|
-@ucode	x12200.x121F2
+@sign	|LU₂×(EŠ₂.LAL)|
+@ucode	x1238A
 @v	[...]
 @v	ešela
 @v	ešelal


### PR DESCRIPTION
Follow-up on #5: 𒎊 and 𒍹 were added in Unicode 7.0.

I believe that both signs are currently incorrectly parenthesized in the OGSL, perhaps as a result of confusion arising from MZL’s notation which uses spacing instead of parentheses.

I believe the sign currently called `|LU₂×EŠ₂.LAL|` with the values `@v ešela` and `@v ešelal`, with a `@form ~a |LU₂.EŠ₂.LAL|`, is the one described in MZL Kap. II, in 514 𒇽 (bottom of p. 143):
> 𒇽𒂠𒇲, auch 𒇽× 𒂠𒇲 — LÚ-ŠÈ(d.h. ÉŠ(E))-LAL bzw.
> LÚ× ŠÈ(d.h. ÉŠ(E))-LAL — ŠL 536,266 c und p1042 N 853
> Vokabulare: MSL 14 461f. (Lww. abgebrochen bzw. ešelal) […]

where MSL 14 461f. is present in DCCLT, whose transliteration has [ešela LU₂×(EŠ₂.LA₂)](http://oracc.museum.upenn.edu/dcclt/P258842#a.P258842.21), and thus that it ought to be called LU₂×(EŠ₂.LAL) (and correspond to 𒎊 rather than 𒈐𒇲).

Similarly, I believe that the sign currently called `|GA₂×AN.KAK.A|` with the value `@v	usud` is the one described in MZL Kap. II, p. 119:
> 393 𒍹 — GÁ× AN-GAG-A — ŠL 238
> Vokabular: MSL 14 366 (Lw. usud).

DCCLT appears to concur: http://oracc.museum.upenn.edu/dcclt/signlists/P391514#a.P391514.274
