### PR TITLE
Add 𒍶, replacing 𒁿

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -4235,10 +4235,18 @@
 @ucode x1234F.x12244
 @end sign
 
-@sign	|DUB×EŠ₂|
+@nosign	|DUB×EŠ₂|
 @uphase	1
 @uname	CUNEIFORM SIGN DUB TIMES ESH2
 @ucode	x1207F
+@v	gaz₃
+@note  Perhaps a misreading DUB×ŠÈ=DUB×EŠ₂ of DUB×ŠE.
+@end sign
+
+@sign	|DUB×ŠE|
+@uname	CUNEIFORM SIGN DUB TIMES SHE
+@list MZL243
+@ucode	x12376
 @v	gaz₃
 @end sign
 


### PR DESCRIPTION
Follow-up on #5: 𒍶 was added in Unicode 7.0.

OGSL gives DUB×EŠ₂ the value gaz₃, and has no DUB×ŠE.
MZL gives MZL243 DUB×ŠE the value gaz₃, and has no DUB×EŠ₂.
MZL cites Revue d’Assyriologie et d’archéologie orientale 60 p. 92, wherein Civil writes DUB×ŠE.
Civil cites TuM 5, 8 : IV 2, and also mentions PBS 9, 65 : 1, 5 ; 112 : 4.
In CDLI, these are:
- TMH 05, 008: https://cdli.ucla.edu/search/archival_view.php?ObjectID=P020422;
- PBS 09, 065: https://cdli.ucla.edu/search/archival_view.php?ObjectID=P216303;
- PBS 09, 112: https://cdli.ucla.edu/search/archival_view.php?ObjectID=P216297.

All look like they have a ŠE, rather than an EŠ₂, inside the DUB.

I kept a `@nosign` for 𒁿, since it has its own code point.
My best guess for why we ended up with a DUB×EŠ₂ would be a misreading of the transliteration, DUB×ŠÈ=DUB×EŠ₂ for DUB×ŠE, so I put that in the `@note`.
