### PR TITLE
Disunify TI₂ from ḪI and DIN

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -3835,7 +3835,6 @@
 @ucode	x12077
 @v?	dan₅
 @v	den
-@v	di₂
 @v	din
 @v	dini
 @v	gurun₈
@@ -3843,7 +3842,6 @@
 @note	Value idinₓ is not listed in MZL and seems unnecessary.
 @v	kurun₂
 @v	ten₂
-@v	ti₂
 @v-	tilₓ
 @note	Value tilₓ is not listed in MZL and seems unnecessary.
 @v	tim₃
@@ -9405,8 +9403,6 @@
 @v	ʾi₃
 @v	da₁₀
 @v	dab₃
-@v	de₈
-@v	di₂
 @v	du₁₀
 @v	dub₃
 @v	dug₃
@@ -9418,12 +9414,8 @@
 @v	kugu
 @v	muₓ
 @v	ta₈
-@v	te₂
-@v	ti₂
 @v	ṭa₃
 @v	ṭab₆
-@v	ṭe₂
-@v	ṭi₂
 @end sign
 
 @sign	|HI.A|
@@ -24488,6 +24480,19 @@
 @v	tana [Diri 6 = Q000151 B28, ta-na-a TI@t.KU₆ ṣippatu]
 @v	%akk/n tibnu
 @note	The value tibnu is assigned to TI@t, but it is not impossible that it belongs to TI.
+@end sign
+
+@sign TI₂
+@list HZL335
+@list MZL633
+@uname CUNEIFORM SIGN TI2
+@ucode x12397
+@v	ṭi₂
+@v	ṭe₂
+@v	ti₂
+@v	te₂
+@v	de₈
+@v	di₂
 @end sign
 
 @sign	TIL


### PR DESCRIPTION
Currently OGSL has ti₂ and di₂ as values of both ḪI (𒄭) and DIN (𒁷), and de₈, te₂, ṭe₂, and ṭi₂ as values of ḪI.

In Unicode Version 7.0, U+12397 CUNEIFORM SIGN TI2 (𒎗) was encoded.

Its disunification from ḪI and DIN follows from principle 11 (mergers and splits) of the _Basic principles for the encoding of Sumero-Akkadian Cuneiform_ [L2/03-162](http://www.unicode.org/L2/L2003/03162-n2585-cuneiform.pdf), but TI₂ is somewhat peculiar in that it is affected _both_ by a split (from DIN) and a merger (with ḪI).

This is perhaps most clearly shown in Labat (MÉA396 and MÉA465).

The following table illustrates the glyph changes through the split and merger using line art from CDLI.

| Code Point | Sign | MZL | ED IIIa | Ur III | OA | MA |
|---|---|---|---|---|---|---|
| U+1212D | ḪI | 631 | [![image](https://user-images.githubusercontent.com/2284290/204140508-49b66701-8d64-4e81-b9e0-465a261f752b.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P225950) | [![image](https://user-images.githubusercontent.com/2284290/204141627-7c3aa222-718d-4a89-a800-bb2a07373930.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P142296)  | [![image](https://user-images.githubusercontent.com/2284290/204141910-52c7cf0a-6a8b-4426-8b6f-dd88111641eb.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P360975) | [![image](https://user-images.githubusercontent.com/2284290/204145564-f3d12906-f892-409c-9e30-7364b510f0a8.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P282017)
| U+12397 | TI₂ | 633 | | [![image](https://user-images.githubusercontent.com/2284290/204141683-f4a5671e-cb00-4ca7-be0e-02e509ea8d1c.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P142296) | [![image](https://user-images.githubusercontent.com/2284290/204141854-af8216a8-02f9-43d7-b0e5-ec7da5ff64ea.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P360975) | [![image](https://user-images.githubusercontent.com/2284290/204145403-3ded6444-a759-40a6-b81a-0256c0347af0.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P282017)
| U+12077 | DIN | 119 | [![image](https://user-images.githubusercontent.com/2284290/204140306-c9c6d774-0958-4886-aaaf-ffb5de1aa1d4.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P225950) | [![image](https://user-images.githubusercontent.com/2284290/204146378-274e2bc9-7f72-4099-82c8-2de4898c80b5.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P103303) |  | [![image](https://user-images.githubusercontent.com/2284290/204145492-17a7916d-c099-464f-93a0-2e5e06890029.png)](https://cdli.ucla.edu/search/search_results.php?ObjectID=P282017) |

Accordingly, this change creates a sign TI₂ with the values  ti₂, di₂, de₈, te₂, ṭe₂, and ṭi₂, which are listed both in MZL633 and in the relevant row of MÉA396, removing those values from ḪI and DIN.