### PR TITLE
Updates to ucode entries with two more code points from Unicode 7.0 and 8.0

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -17990,7 +17990,7 @@
 @sign	|MAŠ.U.U|
 @list MZL126
 @list SLLHA074+471
-@ucode	x12226.x1230B.x1230B
+@ucode	x12226.x12399
 @v-    saŋgidim [CUSAS 12, JON 38 = dcclt:P414356 ii 11', MAŠ saŋ-gi-di-im |U.U| = ma-a-šu]
 @note  The gloss is a conflation of gidim₂(|MAŠ.U|) and saŋmin(|MAŠ.U.U|)
 @v      mašmin [MA Ea = dcclt:P345960 o iv 20']
@@ -23432,7 +23432,7 @@
 @end sign
 
 @sign	|ŠA₃.U.U|
-@ucode x122AE.x1230B.x1230B
+@ucode x122AE.x12399
 @inote OBMC
 @v	tigidlaₓ
 @end sign
@@ -26583,7 +26583,7 @@
 @list MZL708
 @list OBZL363
 @list SLLHA471
-@ucode	x1230B.x1230B
+@ucode	x12399
 @v	amna₂
 @v	buzur₂
 @v	gešₓ

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -11427,7 +11427,7 @@
 @end sign
 
 @sign	|IM.NI.UD|
-@ucode	x1214E.x1224C.x12313
+@ucode	x1214E.x1238E
 @v	enaqa
 @end sign
 
@@ -19424,7 +19424,7 @@
 @list OBZL262
 @list SLLHA229n
 @list KWU779
-@ucode	x1224C.x12313
+@ucode	x1238E
 @v	%akk abnu
 @v	%akk aban
 @v	atumₓ
@@ -19443,12 +19443,12 @@
 @end sign
 
 @sign	|NI.UD.EN|
-@ucode	x1224C.x12313.x12097
+@ucode	x1238E.x12097
 @v	enna
 @end sign
 
 @sign	|NI.UD.KI|
-@ucode	x1224C.x12313.x121A0
+@ucode	x1238E.x121A0
 @v	atum
 @end sign
 


### PR DESCRIPTION
U+1238E CUNEIFORM SIGN NA4 (𒎎) was added in Unicode Version 7.0 (it should help with making Neo-Assyrian fonts, as Neo-Assyrian 𒎎 NA₄ has two vertical wedges on the right, whereas Neo-Assyrian 𒌓 UD has only one).
U+12399 CUNEIFORM SIGN U U (𒎙) was added in Unicode Version 8.0 (cf. 𒌍 U.U.U from Unicode Version 5.0).

This completes the to-do list from #5, with the exceptions of 𒍴 DAG₃ and 𒎕 PIR₂ (both from Unicode Version 7.0). These would require disunifications (from 𒎎 NA₄ and 𒂟 ERIN₂), but whereas I saw a point to the disunification of 𒎗 TI₂ (which is necessary at least for Old Assyrian, see #8), I cannot find a reason to disunify those two (aside from being separate in MZL), so I would like to do some more research before proceeding with them.