### PR TITLE
Typo in the sign name for 𒍳

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -8924,10 +8924,6 @@
 @list	ELLES347
 @list	LAK695
 @list	ZATU174
-@uname	CUNEIFORM SIGN GA2 TIMES HA PLUS A
-@list	U+124BE
-@utf8	𒒾
-@uage	8.0
 @@
 @form |LAGAB×HA|
 @list	LAK784a

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -4953,7 +4953,7 @@
 @v	uburₓ
 @end sign
 
-@sign |DAG.KISIM₅×(U.MAŠ)|
+@sign |DAG.KISIM₅×(U₂.MAŠ)|
 @uname	CUNEIFORM SIGN DAG KISIM5 TIMES U2 PLUS MASH
 @list	U+12373
 @utf8	𒍳


### PR DESCRIPTION
(One of the commits in this PR removed the encoding of |GA₂×(HA.HA)| added in e4172cff36e06e56f03594bb015a19b0d6a3b153, but it looks like @stinney beat me to it in fd0a0d8514b7ed1db42fdccb63217a817d74469e.)