### PR TITLE
Add sixteen missing ELLes numbers

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -2926,6 +2926,7 @@
 @list	BAU051
 @list	BAU052
 @list	BAU053
+@list	ELLES035
 @list	HZL016
 @list	KWU090
 @list	MZL018

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -27949,6 +27949,7 @@
 
 @sign PEŠ₂
 @list	ABZL418
+@list	ELLES146
 @list	HZL003
 @list	LAK245
 @list	MZL741
@@ -27977,7 +27978,6 @@
 @@
 @form LAK247
 @list	ELLES145
-@list	ELLES146
 @list	LAK247
 @list	RSP460bis
 @v	kilim

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -1061,6 +1061,7 @@
 
 @sign |A×HA|
 @list	ABZL471
+@list	ELLES394
 @list	KWU907
 @list	LAK796
 @list	MZL846
@@ -2758,6 +2759,7 @@
 @list	ABZL292
 @list	BAU161a
 @list	BAU161c
+@list	ELLES140
 @list	HZL302
 @list	KWU460
 @list	LAK253
@@ -5330,6 +5332,7 @@
 @end sign
 
 @sign |DIM×MAŠ|
+@list	ELLES032
 @v	mašgurₓ
 @note	M. Civil ZA 74, 162
 @end sign
@@ -7710,6 +7713,7 @@
 @sign EREN
 @list	ABZL398
 @list	BAU373
+@list	ELLES327
 @list	HZL062
 @list	KWU895
 @list	LAK665
@@ -9728,6 +9732,7 @@
 @end sign
 
 @sign |GA₂×(NE.E₂)|
+@list	ELLES374
 @list	LAK692
 @list	ZATU251
 @uname	CUNEIFORM SIGN GA2 TIMES NE PLUS E2
@@ -11233,6 +11238,7 @@
 
 @sign GIDIM
 @list	ABZL426
+@list	ELLES191
 @list	HZL052
 @list	MZL830
 @list	SLLHA576
@@ -21143,6 +21149,7 @@
 @end sign
 
 @sign |LAK449×(AN.EŠ₂)|
+@list	ELLES235
 @inote	gvl unknown compound
 @end sign
 
@@ -21191,6 +21198,7 @@
 @end sign
 
 @sign |LAK449×SI|
+@list	ELLES236
 @inote	gvl unknown compound
 @end sign
 
@@ -24024,6 +24032,7 @@
 @end sign
 
 @sign |MUŠ×KUR|
+@list	ELLES134
 @uname	CUNEIFORM SIGN MUSH TIMES KUR
 @list	U+12234
 @ucun	𒈴
@@ -27967,6 +27976,8 @@
 @form LAK244
 @@
 @form LAK247
+@list	ELLES145
+@list	ELLES146
 @list	LAK247
 @list	RSP460bis
 @v	kilim
@@ -28165,6 +28176,7 @@
 @sign PIRIG
 @list	ABZL178
 @list	BAU162
+@list	ELLES144
 @list	LAK257
 @list	RSP460
 @list	SLLHA444
@@ -28269,6 +28281,7 @@
 @v	uq
 @form PIRIG
 @list	BAU162
+@list	ELLES144
 @list	LAK257
 @list	RSP460
 @v	ug⁻
@@ -28313,6 +28326,7 @@
 @v	uz₄
 @form PIRIG
 @list	BAU162
+@list	ELLES144
 @list	LAK257
 @list	RSP460
 @v	az⁻
@@ -30932,6 +30946,7 @@
 @end sign
 
 @sign |ŠA₃×SAL|
+@list	ELLES231
 @v	pešₓ
 @end sign
 
@@ -33162,6 +33177,7 @@
 @v	šudun
 @v	šutul
 @form ELLES302
+@list	ELLES302
 @@
 @end sign
 
@@ -36389,6 +36405,7 @@
 @end sign
 
 @sign |UMUM×HA|
+@list	ELLES086
 @inote	@uname-no-char	CUNEIFORM SIGN UMUM TIMES HA
 @v	agarinₓ
 @lit	Civil 2008 ARES 4, 78


### PR DESCRIPTION
Based on the transliterations in dcclt/ebla of the attestations given in ELLes, see the table below.

Note that for ELLES035 I have disregarded 48 r. III 16–17, [P241498 o iii 16–17](http://oracc.museum.upenn.edu/dcclt/P241498?P241498.55,P241498.56). Those are transliterated AŠ.SÌLA in MEE3 and simply sila₃ in dcclt/ebla, corresponding to 𒀸𒋡 or just 𒋡, whereas the attestation from MEE 3 43 is arad 𒀴. If a distinction with normal sila₃ needed to be made in dcclt/ebla, I guess an `@form` of sila₃ would be needed.

Thanks to @erica-scarpa for providing me with a copy of MEE 3.

| ELLes # | ELLes reference | MEE 3 transliteration | dcclt/ebla reference | dcclt/ebla transliteration | 
|---|---|---|---|---|
| 32 | 48 r. IV 3 | **DIM×MAŠ** | [P241498 o iv 3](http://oracc.museum.upenn.edu/dcclt/P241498?P241498.60) | **DIM×MAŠ** |
| 35 | 43 v. V 7′ | _**ìr**-az-il_ | [Q000010 colophon 7](http://oracc.museum.upenn.edu/dcclt/Q000010?Q000010.300) | **arad**-⸢az⸣-il
| 86 | 45 r. V 6′ | **UMÚN×ḪA**-⸢x⸣ | [P241395 o v 14](http://oracc.museum.upenn.edu/dcclt/P241395?P241395.101) | **aŋarinₓ(UMUM×ḪA)** |
| 134 | 39 r. VII 15 | gi-**MUŠ×KUR**-mušen | [P240986 o vii 15](http://oracc.museum.upenn.edu/dcclt/P240986?P240986.132) | gi-**MUŠ×KUR**<sup>mušen</sup>
| 140 | 45 r. IV 9′ | **ANŠE** bur | [P241395 o iv 17](http://oracc.museum.upenn.edu/dcclt/P241395?P241395.83) | BUR **ANŠE<sup>?</sup>** |
| 144 | 47 r. V 5 | é-**PIRIG**-E[ZEN] | [P241483 o v 5](http://oracc.museum.upenn.edu/dcclt/P241483?P241483.75) | E₂-**PIRIG**-⸢EZEN⸣ |
| 145 | 18 r. V 4–5 | **pirigₓ** / kur-**pirigₓ** | [P241517 o v 4–5](http://oracc.museum.upenn.edu/dcclt/P241517?P241517.90,P241517.91) | **PEŠ₂(LAK247)** / **PEŠ₂(LAK247)**::kur
| 146 | 51 v. III 2 | **_ELLes_, n. 146** | [P240957 r iii 2](http://oracc.museum.upenn.edu/dcclt/P240957?P240957.97)	| **PEŠ₂** 
| 191 | 56 r. I 1<br>7 r. IV 4, 6<br>18 r. VI 13| _ḫa_-**GIDIM**<sup>ki</sup> <br> PA-**gidim** / nu-**gidim** <br> **GIDIM**-[ ] | [P241795](http://oracc.iaas.upenn.edu/dcclt/P241795/)<br>[P010101 o iv 4, 6](http://oracc.museum.upenn.edu/dcclt/P010101?P010101.53,P010101.55)<br>[P241517 o vi 13](http://oracc.museum.upenn.edu/dcclt/P241517?P241517.109) | (none)<br>⸢PA-**GIDIM**⸣ / nu-⸢**gidim**⸣<br>**GIDIM** |
| 231 | 18 r. I 12, II 14 | **ŠÀ×SAL**<sup>?</sup>-áb / **ŠÀ×SAL**-ùz | [P241517 o i 12, ii 14](http://oracc.museum.upenn.edu/dcclt/P241517?P241517.14,P241517.37) | ⸢**pešₓ(ŠA₃×SAL)**⸣ ab₂ / **pešₓ(ŠA₃×SAL)** uzud
| 235 | 45 v. V 6 | **ḪUBUR×AN.ŠÈ** | [P241395 r v 6](http://oracc.museum.upenn.edu/dcclt/P241395?P241395.341) | **LAK449×(AN.ŠE₃)** |
| 236 | 45 v. IV 19 | **ḪUBUR×SI** | [P241395 r iv 19](http://oracc.museum.upenn.edu/dcclt/P241395?P241395.333) | **LAK449×SI**
| 302 | 44 r. III 3<br>51 v. II 3<br>52 v. II 9 | DIL **uštil** giš-NÁM<br>**_ELLes_, n. 302**<br>**_ELLes_, n. 302** | [P241092 o  iii 3](http://oracc.museum.upenn.edu/dcclt/P241092?P241092.27)<br>[P240957 r ii 3](http://oracc.museum.upenn.edu/dcclt/P240957?P240957.83)<br>[P218313 r ii 11](http://oracc.museum.upenn.edu/dcclt/P218313?P218313.82) | * **šudun(ELLES302)** giš-taskarin<br>**ŠU₂.DUN₃<sup>ggs</sup>**<br>**ŠU₂.DUN₃<sup>ggs</sup>**
| 327 | 44 r. IX 1–2 | giš-**eren**-⸢x⸣ / giš-**eren**  | [P241092 o ix 1–2](http://oracc.museum.upenn.edu/dcclt/P241092?P241092.127,P241092.128) | giš-**ERIN**.⸢A?⸣ / giš-**erin**
| 374 | 47 r. I 7 | 5 **LAGAB×NE.É** | [P241483 o i 7](http://oracc.museum.upenn.edu/dcclt/P241483?P241483.9) | 5(AŠ<sup>c</sup>) **GA₂×(NE.E₂)**
| 394 | 53 r. III 15 | **zàḫ** | [P241823 o iii 15](http://oracc.museum.upenn.edu/dcclt/P241823?P241823.55) | **zaḫ₃**