### PR TITLE
LAK400 is 𒋝, not 𒌓

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -30063,6 +30063,7 @@
 @list	KWU342
 @list	LAK400
 @list	MZL881
+@list	REC256
 @list	RSP317
 @list	SLLHA592
 @uname	CUNEIFORM SIGN SIG
@@ -35618,6 +35619,7 @@
 @list	KWU345
 @list	LAK379
 @list	MZL596
+@list	REC234
 @list	RSP319
 @list	RSP322
 @list	RSP324

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -30061,6 +30061,7 @@
 @list	BAU202
 @list	HZL255
 @list	KWU342
+@list	LAK400
 @list	MZL881
 @list	RSP317
 @list	SLLHA592
@@ -35616,7 +35617,6 @@
 @list	HZL316
 @list	KWU345
 @list	LAK379
-@list	LAK400
 @list	MZL596
 @list	RSP319
 @list	RSP322


### PR DESCRIPTION
Another one spotted by comparison with Catagnoti’s list.

LAK400 cites:
- ud-R-im 9124, 1; [oracc/dcclt](http://oracc.museum.upenn.edu/dcclt/P010649) and [CDLI](https://cdli.mpiwg-berlin.mpg.de/artifacts/10649/) have ud sig ni₂ 𒌓𒋝𒉎 there;
- REC256,
  - which cites Gud B, V, 26, where [oracc/etcsri](http://oracc.iaas.upenn.edu/etcsri/Q001541) has a-ab-ba sig-ga-še₃ 𒀀𒀊𒁀​𒋝𒂵𒂠;
- 𒋝-ga, DP66, 4; [CDLI](https://cdli.mpiwg-berlin.mpg.de/artifacts/220716) has iri-sig-ga 𒌷𒋝𒂵 there.


Also added the RÉC numbers for both while I am here.
