### PR TITLE
Try to sort out the KU₄ situation

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -22116,6 +22116,7 @@
 @list	KWU147
 @list	LAK094
 @list	MZL544
+@list	REC056
 @list	RSP127
 @list	SLLHA336
 @lit	Krecher ZA 77 (1987), 17-21

--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -18642,9 +18642,8 @@
 @list	ABZL375
 @list	KWU636
 @list	MZL087
-@list	REC145
+@list	REC144
 @list	SLLHA058
-@inote	##CHECK REC no.
 @lit	Krecher, ZA 77 (1987), 17-21; Veldhuis, FS Sigrist (2009), 226-228
 @uname	CUNEIFORM SIGN KU4
 @list	U+121AD
@@ -18656,9 +18655,11 @@
 @v	kur₉
 @v	lilₓ
 @v	sunₓ
-@form KU₄~a
-@list	KWU147
-@inote	##CHECK LAK/KWU/REC no. This is ED LIL; No separate uname/ucode needed? FIXME
+@form REC145
+@aka KU₄~a
+@list	KWU634
+@list	REC145
+@list	LAK208
 @uname	CUNEIFORM SIGN KU4 VARIANT FORM
 @list	U+121AE
 @ucun	𒆮
@@ -18666,14 +18667,11 @@
 @v	ku₄
 @v	kur₉
 @@
-@form KWU634
-@inote	KWU634 = ŠE.ŠU&ŠU@h
-@@
-@form REC144
-@inote	etcsri -- check -- REC144 = ŠE.ŠU
-@@
-@form REC56
-@inote	etcsri -- check -- REC56 = ŠU&ŠU@r
+@form LIL
+@list	KWU147
+@list	LAK094
+@list	REC056
+@ucun	𒇸
 @@
 @end sign
 
@@ -22116,7 +22114,7 @@
 @list	ABZL091
 @list	HZL127
 @list	KWU147
-@list	LAK208
+@list	LAK094
 @list	MZL544
 @list	RSP127
 @list	SLLHA336
@@ -22131,6 +22129,14 @@
 @v	lil
 @v	sukuₓ
 @v	šaₓ
+@form REC145
+@aka KU₄~a
+@lit	Krecher 1973 https://doi.org/10.1515/zava.1973.63.2.145 p. 232
+@list	KWU634
+@list	REC145
+@list	LAK208
+@ucun	𒆮
+@@
 @end sign
 
 @sign LIMMU
@@ -28955,11 +28961,6 @@
 @@
 @end sign
 
-@sign RSP126
-@inote	admin/names
-@v	šuₓ
-@end sign
-
 @sign RSP194
 @list	RSP194
 @end sign
@@ -33497,13 +33498,14 @@
 @end sign
 
 @sign |ŠU&ŠU@180|
-@list	LAK094
 @list	RSP126
 @uname	CUNEIFORM SIGN SHU OVER INVERTED SHU
 @list	U+122D8
 @ucun	𒋘
 @uage	5.0
 @v	lilₓ?
+@inote	admin/names
+@v	šuₓ
 @inote	better ŠU&ŠU@h because the lower sign is reflected about the horizontal axis not rotated 180
 @end sign
 


### PR DESCRIPTION
That one took a while to untangle.

@stinney, I noticed that etcsri has kur₉(REC56) rather than kur₉(REC056); is the validation tool resilient to that sort of thing, or should we have an `@aka REC56` on sign/form LIL?

### Summary

I. REC056 = LAK094 = KWU147 = U+121F8 𒇸 CUNEIFORM SIGN LIL, which looks like this on Gudea Cylinder B:

| Oracc/etcsri transliteration <img width=1000> | Cuneiform <img width=1000> | Photo |
|---|---|---|
| ur‑saŋ<br>e₂&nbsp;gibil‑<br>na&nbsp;ur₉(REC56)‑ra‑<br>am₃ | 𒌨𒊕<br>𒂍​𒉋<br>𒈾​𒇸𒊏<br>𒀀𒀭 | ![𒌨𒊕​𒂍​𒉋𒈾​𒇸𒊏𒀀𒀭](https://github.com/oracc/ogsl/assets/2284290/921fbda7-84df-4261-874b-a604ae3bcc17) |

II. REC144 = KWU636 = U+121AD CUNEIFORM SIGN KU4 𒆭, which looks like this on Gudea Cylinder B:

| Oracc/etcsri transliteration <img width=1000> | Cuneiform <img width=1000> | Photo |
|---|---|---|
| ud&nbsp;lugal‑ni<br>e₂‑a&nbsp;kur₉(REC144)‑ra | 𒌓​𒈗𒉌<br>𒂍𒀀​𒆭𒊏  | ![ 𒌓​𒈗𒉌​𒂍𒀀​𒆭𒊏](https://github.com/oracc/ogsl/assets/2284290/d11ed813-c1fd-4e60-a7cd-f7d0060ccff2) |

III. REC145 = LAK208 = KWU634 = U+121AE 𒆮 CUNEIFORM SIGN KU4 VARIANT FORM, which looks like this on Gudea Statue B:

| Oracc/etcsri transliteration <img width=1000> | Cuneiform <img width=1000> | Photo |
|---|---|---|
| mi‑ni‑kur₉(REC145) | 𒈪𒉌𒆮 | ![𒈪𒉌𒆮](https://github.com/oracc/ogsl/assets/2284290/340cd60f-cd76-40e8-a513-176c1831cc6e) |


All three are forms of KU₄. LIL is LIL, and REC145 may be a form of LIL.

RSP126 = U+122D8 𒋘 CUNEIFORM SIGN SHU OVER INVERTED SHU is its own thing, with the value šuₓ—and it looks a bit like contemporary LIL (RSP127), just to confuse everyone.  Its Unicode reference glyph should probably be corrected, it does not look very much like `𒋗&𒋗@h`, nor like the exemplar for RSP126.

### Details

1. LAK094 = REC056: Deimel says so.
2. LAK094 = REC056 is LIL=KWU147, which is a form of ku₄=kur₉:
   | Citation in LAK | CDLI | Oracc | CDLI transliteration | Oracc transliteration |
   |---|---|---|---|---|
   | DP 135, 10 | [P220785](https://cdli.mpiwg-berlin.mpg.de/artifacts/220785) | [epsd2/P220785](http://oracc.museum.upenn.edu/epsd2/P220785) | a-lu2-lil-la | a-lu₂-lil-la
   | [DP] 321, 2 | [P220971](https://cdli.mpiwg-berlin.mpg.de/artifacts/220971) | [epsd2/P220971](http://oracc.museum.upenn.edu/epsd2/P220971) | a-lu2-lil-la | a-lu₂-lil-la
   | [VAT] 12655, 6 | [P10604](https://cdli.mpiwg-berlin.mpg.de/artifacts/10604/) | [epsd2/P010604](http://oracc.museum.upenn.edu/epsd2/P010604) | | gu₇ ka ku₄!(LAK094-)ra
   | CT1,4,3 | [P108393](https://cdli.mpiwg-berlin.mpg.de/artifacts/108393) | [epsd2/P108393](http://oracc.museum.upenn.edu/epsd2/P108393) | ga2-nun sanga ba-an-kux(KWU147) | ga₂-nun sanga ba-an-kuₓ(KWU147)
   
   | Citation in REC | CDLI | Transliteration source | Transliteration |
   |---|---|---|---|
   | Sarg AOT b 55, Endr I 8 | [P494457](https://cdli.mpiwg-berlin.mpg.de/artifacts/494457) | [Huber 2022](https://openscience.ub.uni-mainz.de/bitstream/20.500.12030/7790/1/girsutexte_der_akkadezeit_im_-20220915195604271.pdf) | \[d]umu Lú-lil-lum |
   | Gud Cyl B XIX, 5<sup>e</sup> av der. case | [P232301](https://cdli.mpiwg-berlin.mpg.de/artifacts/232301) | CDLI | ur-sag e2 gibil-na kux(KWU147)-ra-am3
   | 𒈫 | 𒈫 | [etcsri/Q000377](http://oracc.museum.upenn.edu/etcsri/Q000377) | ur-saŋ e₂ gibil-na kur₉(REC56)-ra-am₃
   
   - **Note:** LAK094 also cites  12761, 5 = [P010573](https://cdli.mpiwg-berlin.mpg.de/artifacts/10573) and 12426, 3 = [P010591](https://cdli.mpiwg-berlin.mpg.de/artifacts/10591) for which I found no transliteration, as well as STH 2, 106 = [P110379](https://cdli.mpiwg-berlin.mpg.de/artifacts/110379) for which CDLI and [ePSD2](http://oracc.museum.upenn.edu/epsd2/P110379) have `tibir?`.

3. LAK208 = REC145: Both cite Gudea Statue B, column 7, cell 46.
5. LAK208 = REC145 is a form of ku₄=kur₉; it might also be a form of lil:
   | Citation in LAK | CDLI | Oracc | CDLI transliteration | Oracc transliteration |
   |---|---|---|---|---|
   | é-R, Nik. 9, 1 | [P221716](https://cdli.mpiwg-berlin.mpg.de/artifacts/221716) | [epsd2/P221716](http://oracc.museum.upenn.edu/epsd2/P221716) | e2-ku4 | e₂-ku₄ |
   | RTC 65, 2 | [P221462](https://cdli.mpiwg-berlin.mpg.de/artifacts/221462) | [epsd2/P221462](http://oracc.museum.upenn.edu/epsd2/P221462) | GAN2 u3-du10-ku4-kam | GAN₂ u₃-du₁₀-ku₄-kam
   | [RTC] 68, 1 | [P221465](https://cdli.mpiwg-berlin.mpg.de/artifacts/221465) | [epsd2/P221465](http://oracc.museum.upenn.edu/epsd2/P221465) | GAN2 u3-du10-ku4-bi | GAN₂ u₃-du₁₀-ku₄-bi
   | [RTC] 71, 5 | [P221468](https://cdli.mpiwg-berlin.mpg.de/artifacts/221468) | [epsd2/P221468](http://oracc.museum.upenn.edu/epsd2/P221468) | \[GAN2] u3-du10-ku4-kam | \[GAN₂] u₃-du₁₀-ku₄-kam
   | Gud. B 7, 46 | [P232275](https://cdli.mpiwg-berlin.mpg.de/artifacts/232275) | [etcsri/Q001541](http://oracc.museum.upenn.edu/etcsri/Q001541) | mi-ni-kux(KWU634) | mi-ni-kur₉(REC145) |

   The last one is also cited in REC (Gud. B, VII, 46).
   - **Note 1:** LAK has the following reference, but it must be a mistake in LAK, as 1. the sign does not look like LAK208, even though it is cited as R, see copy and photo in CDLI; 2. the same occurrence is cited in LAK094 (see above).
     | Citation in LAK | CDLI | Oracc | CDLI transliteration | Oracc transliteration |
     |---|---|---|---|---|
     | Lú-R(=lil)-la, (DP135, 10) | [P220785](https://cdli.mpiwg-berlin.mpg.de/artifacts/220785) | [epsd2/P220785](http://oracc.museum.upenn.edu/epsd2/P220785) | a-lu2-lil-la | a-lu₂-lil-la |
   - **Note 2:** LAK and REC both have the following reference; there the transliteration in CDLI and epsd2 is erroneous, and should be kuₓ(KWU634), see photo and copy (also mind the column number, Deimel wrote 3 but this is in column r ii = 4).
   
     | Citation in REC | Citation in LAK | CDLI | Oracc | CDLI transliteration | Oracc transliteration |
     |---|---|---|---|---|---|
     | Sarg TCI n<sup>o</sup> 61, Env. II, 1  | RTC 142, 3 (sic) | [P216921](https://cdli.mpiwg-berlin.mpg.de/artifacts/216921) | [epsd2/P216921](http://oracc.museum.upenn.edu/epsd2/P216921) | GAN2 u3-du10-kux(KWU147) | GAN₂ u₃-du₁₀-kuₓ(KWU147)
   - **Note 3:** LAK also has the reference TDT 1, 1133 = [P213598](https://cdli.mpiwg-berlin.mpg.de/artifacts/213598); while I could not find a transliteration of it, this one may really have a lu₂-lil(REC145)-la, see [Krecher 1973](https://www.degruyter.com/document/doi/10.1515/zava.1973.63.2.145/html) p. 232.

6. REC145 = KWU634: Compare REC and KWU, and compare the CDLI and Oracc etcsri transliterations of Gudea Statue B, column 7, cell 46, above.
7. REC144 = KWU636: Compare REC and KWU, and compare the CDLI and Oracc etcsri transliterations of Gudea Cylinder B, column 19, cell 18:
   | Citation in REC | CDLI | Oracc | CDLI transliteration | Oracc transliteration |
   |---|---|---|---|---|
   | Gud. Cyl. B, XVII, 18 | [P232301](https://cdli.mpiwg-berlin.mpg.de/artifacts/232301) | [etcsri/Q000377](http://oracc.museum.upenn.edu/etcsri/Q000377) | u4 lugal-ni e2-a kux(KWU636)-ra | ud lugal-ni e₂-a kur₉(REC144)-ra |
8. RSP126 cites TSA 3,I with the value šuₓ; this is [P221364](https://cdli.mpiwg-berlin.mpg.de/artifacts/221364) en-szux(RSP126)-gi4-gi4, which is the only occurrence of RSP126 in a CDLI transliteration.
