### PR TITLE
Fix ABZL, HZL, MZL, and SLLHA numbers for 𒂅, 𒂆, and 𒂇

### DIFF
--- a/00lib/ogsl.asl
+++ b/00lib/ogsl.asl
@@ -6594,6 +6594,7 @@
 @list	ABZL401a
 @list	BAU280
 @list	BAU340
+@list	HZL223
 @list	KWU858
 @list	LAK666
 @list	MZL836
@@ -6667,13 +6668,13 @@
 @list	ABZL401b
 @list	BAU339
 @list	ELLES325
-@list	HZL096
+@list	HZL223
 @list	KWU859
 @list	LAK667
-@list	MZL556
+@list	MZL836
 @list	PTACE269
 @list	RSP305
-@list	SLLHA347
+@list	SLLHA595
 @uname	CUNEIFORM SIGN DUN3 GUNU
 @list	U+12086
 @ucun	𒂆
@@ -6698,10 +6699,15 @@
 @end sign
 
 @sign DUN₃@g@g
+@list	ABZL219a
+@list	ABZL219b
 @list	ELLES084
+@list	HZL096
 @list	KWU311
 @list	LAK154
+@list	MZL556
 @list	RSP275
+@list	SLLHA347
 @uname	CUNEIFORM SIGN DUN3 GUNU GUNU
 @list	U+12087
 @ucun	𒂇


### PR DESCRIPTION
The HZL, MZL, and SLLHA numbers for MIR were mistakenly on GIN₂ (probably because of confusion arising from the 𒂅-𒂆 DUN₃-GIN₂ merger). The ABZL numbers for MIR were missing.