### PR TITLE
LAK222 is Ur III 𒍜

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -27070,12 +27070,6 @@
 @link	Wikidata Q87557284 http://www.wikidata.org/entity/Q87557284
 @end sign
 
-@sign LAK222
-@list	LAK222
-@oid	o0000328
-@link	eBL LAK222 https://www.ebl.lmu.de/signs/LAK222
-@end sign
-
 @sign LAK225
 @list	LAK225
 @oid	o0000329
@@ -48732,6 +48726,7 @@
 
 @sign UZU
 @list	LAK120
+@list	LAK222
 @list	LAK350
 @list	ASY121
 @oid	o0000592
@@ -48746,6 +48741,8 @@
 @list	SYA105
 @inote	LAK120 is the form from the stela of Hammurabi P249253; Deimel cites
 	r 21 32 and r 27 27.
+	LAK222 is the Ur III form; Deimel cites forms listed in Legrain’s sign list,
+	from P134880 o 2, P134881 o 5, P135087 o 9, P135086 o 1, and P135105 o 8.
 @lit	M. Civil, ZA 74, 162
 @inote	##CHECK Civil CUSAS 12, 211 on LAK350
 @uname	CUNEIFORM SIGN UZU


### PR DESCRIPTION
Deimel writes:

<img width="2230" height="216" alt="image" src="https://github.com/user-attachments/assets/d116303b-b9d6-4015-a0a1-c56a33e93960" />

Legrain writes:

<img width="578" height="376" alt="image" src="https://github.com/user-attachments/assets/9317dc24-198d-431f-9c50-a57ea45682a1" />

[116](http://cdli.earth/P134880), 3; [117](http://cdli.earth/P134881), 7; [322](http://cdli.earth/P135086), 2; [323](http://cdli.earth/P135087), 9; [341](http://cdli.earth/P135105), 9, all have uzu. (Note that the ePSD2 transliteration of [116](http://cdli.earth/P134880) has a typo (udu for uzu); this came from CDLI, but I have corrected it in https://cdli.earth/update-events/132036.)