### PR TITLE
Both the left- and right-gunified forms of 𒋤 are under LAK233, not LAK235

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -39264,16 +39264,18 @@
 @inote	added during ogsl upgrade
 
 @sign SUD
-@list	LAK235^a
+@list	LAK233^a
 @list	ASY215
 @oid	o0000532
 @list	ABZL266
 @list	BAU149
 @list	BAU151
+@list	ELLES132
 @list	GCSL116
 @list	HZL341
 @list	KWU386
 @list	MZL584
+@list	PTACE124
 @list	RSP336
 @list	SLLHA373
 @list	SYA187
@@ -39317,9 +39319,12 @@
 @form BU@g
 @list	LAK233
 @oid	o0000126
-@list	ELLES132
-@list	PTACE124
-@inote	in |PA.EL.BU@g|
+@inote	This is the index form in LAK, gunified on the left, with the other
+	forms shown being gunified on the right.
+	This form occurs in |PA.EL.BU@g| from http://oracc.org/Q000006.122
+	(see the witness P010101 vi 16), but also as ordinary su₃, e.g., in
+	P221472 r ii 1, r iii 2 (ED IIIb Ŋirsu), or
+	P108472 iv 5 (Ur III Ŋirsu), both cited by Deimel.
 @link	eBL BU@g https://www.ebl.lmu.de/signs/BU@g
 @@
 @form LAK233@g


### PR DESCRIPTION
There is no 𒋤 under LAK235, only LAK235 𒈲:
<img width="2241" height="138" alt="image" src="https://github.com/user-attachments/assets/f4158fa4-1477-455e-8da6-d3fd75cb6330" />
and indeed the glyph currently listed as LAK235^a in https://oracc.museum.upenn.edu/listfontdata/lak/#235 is actually from the entry for LAK233—specifically, it is the one from [9078](http://cdli.earth/P010979), 8—:
<img width="2216" height="216" alt="image" src="https://github.com/user-attachments/assets/2f642d19-dbca-480c-8070-6806e5c0d27d" />

Of those citations, two ([9078](http://cdli.earth/P010979), 8 [CT 5, 3](http://cdli.earth/P274787), I2) are gunified on the right, but [RTC 75](http://cdli.earth/P221472)R2 is gunified on the left (at least according to Thureau-Dangin’s copy, with the damage I cannot tell much from the photo), and transliterated as plain su₃, likewise, [CT 3, 36](http://cdli.earth/P108472), 104 has extra wedges on the left compared to 𒁍 in the same text.


The index form says « pass. in d. arch. T. ». Is it the ordinary form of su₃ in some styles? If so, it might not need to be a separate `@form`.

The Eblaite forms are gunified on the right, so they move up to the main sign.