### PR TITLE
gilgameš₂ is 𒄑𒉋𒂵𒈩; 𒄑𒉋𒂵𒎌 does not exist; gilgameš₄ is not needed.

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -15439,8 +15439,8 @@
 @oid	o0221900
 @useq	x12111.x1224B.x120B5.x12229
 @ucun	𒄑𒉋𒂵𒈩
-@v	gilgames₄
-@v	gilgameš₄
+@v	gilgames₂
+@v	gilgameš₂
 @@
 @form |GIŠ.NE@s.MES.GA|
 @oid	o0221976
@@ -15486,11 +15486,13 @@
 @@
 @end sign
 
-@sign |GIŠ.NE@s.GA.ME.U.U.U|
+@sign- |GIŠ.NE@s.GA.ME.U.U.U|
 @oid	o0001382
 @useq	x12111.x1224B.x120B5.x1238C
 @ucun	𒄑𒉋𒂵𒎌
-@v	gilgameš₂
+@note	Typo for gilgameš₂(GIŠ.BIL₂.GA.MES) 𒄑𒉋𒂵𒈩 (MEŠ instead of MES).
+	The spelling 𒄑𒉋𒂵𒎌 is not attested.
+	For many years Oracc mapped gilgameš₂ to this sign, and this has been carelessly copied elsewhere.
 @link	eBL |GIŠ.NE@s.GA.ME.U.U.U| https://www.ebl.lmu.de/signs/|GIŠ.NE@s.GA.ME.U.U.U|
 @end sign
 


### PR DESCRIPTION
The current gilgameš₂(𒄑𒉋𒂵𒎌) in OSL is a straightforward typo (MEŠ instead of MES/MÈŠ); MZL p. 485 assigns gílgames/š to GIŠ-BÍL-GA-MES 𒄑𒉋𒂵𒈩 instead (and gìlgameš to GIŠ-NE-GA-MES 𒄑𒉈𒂵𒈩, which is what the OSL has for gilgameš₃).
The ePSD2 attestations of gilgameš₂ are mostly etcsl composites, so confirming on photos is a bit fiddly, but spot-checking a witness for the SKL (https://oracc.museum.upenn.edu/epsd2/Q000371.125) confirms that etcsl is using the same numbering as Borger here:
<img width="468" height="128" alt="𒌉𒀭𒄑𒉋𒂵𒈩" src="https://github.com/user-attachments/assets/ee28856c-259e-4b9a-8ff7-f37782d574dd" />
from https://cdli.earth/artifacts/384786/reader/176756 clearly doesn’t end with 𒎌.

𒄑𒉋𒂵𒎌 is unattested, see George’s _The Babylonian Gilgamesh Epic_, pp. 71 sqq., and thus gets deprecated.

In https://github.com/oracc/osl/commit/2a94a02a1df387abe86573fb82f5799b7913273e, 𒄑𒉈𒂵𒈩 was added to the OSL, but as gilgameš₄. As discussed over email, gilgameš₄ should be withdrawn as a reading, and the ePSD2 corpus should be fixed to use gilgameš₂ instead.