### PR TITLE
LAK415 is 𒌋𒁇

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -26739,6 +26739,9 @@
 @lref LAK192
 @note Sequence eš-bar
 
+@lref LAK415
+@note Sequence u-bar with references P108624, P128543, and P135731.
+
 @lref LAK436
 @note No drawn sign; some references
 
@@ -27369,11 +27372,6 @@
 @list	LAK410
 @oid	o0000372
 @link	eBL LAK410 https://www.ebl.lmu.de/signs/LAK410
-@end sign
-
-@sign LAK415
-@list	LAK415
-@oid o0038388
 @end sign
 
 @sign LAK416


### PR DESCRIPTION
Deimel writes:
<img width="2280" height="143" alt="" src="https://github.com/user-attachments/assets/94a571bf-b124-45da-bce5-f8f34a23add7" />
With links to CDLI & ePSD2, these references are:
> [CT 10, 40](http://cdli.earth/P108624), [1](http://oracc.org/epsd2/P108624.13); [RTC 390](http://cdli.earth/P128543) [(o 6, o 12)](http://oracc.org/epsd2/P128543.8); [Reisn. TU 158](http://cdli.earth/P135731), [5, ⟨1⟩8](http://oracc.org/epsd2/P135731.147).

Note that Deimel’s location 5, 8 in Reisn. TU 158 is missing a 1; it should be 5, 18 with Reisner’s numbering; in turn Reisner swaps the obverse and reverse, so Reisner’s V 18 is CDLI and ePSD2’s r i 15′.

These all have u-bar in their CDLI and ePSD2 transliterations, lemmatized in ePSD2 [ubar](http://oracc.org/epsd2/o0040885) in the first two texts and as part of the PN Ubartum in Reisn. TU 158.