### PR TITLE
LAK416 is 𒌋𒌆

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -27376,12 +27376,6 @@
 @oid o0038388
 @end sign
 
-@sign LAK416
-@list	LAK416
-@oid	o0025846
-@inote	for dcclt/ebla--check that it is not in OGSL under a different name
-@end sign
-
 @sign LAK431
 @list	LAK431
 @oid	o0025848
@@ -45033,6 +45027,7 @@
 @list	GCSL185
 @list	HZL262
 @list	KWU412
+@list	LAK416
 @list	MZL720
 @list	SLLHA459
 @list	SYA234


### PR DESCRIPTION
This is how Deimel identifies the sign:
<img width="2262" height="180" alt="image" src="https://github.com/user-attachments/assets/7feb8f1a-4c9b-4c92-ac99-3f032344ca25" />

This is also consistent with most of the references he gives:
> [DP55](http://cdli.earth/P220705) R4; [410](http://cdli.earth/P221060); [413](http://cdli.earth/P221063); [223](http://cdli.earth/P220873), 1; [436](http://cdli.earth/P221086), [3](http://oracc.org/epsd2/P221086.21); [446](http://cdli.earth/P221096); [Gud. Cyl. B](http://cdli.earth/P232301),
[15, 10](http://oracc.org/etcsri/Q000377.1162) (R=šù-dŭl)

Of these, DP410, DP413, DP436, DP446, and Gud. Cyl. B have szu₄-dul₅=šudul₂. (For some reason the CDLI transliteration of DP446 got changed from šu₄-dul₅ to šu₄-dulₓ(UR) [in 2008](https://cdli.earth/inscriptions/2117476), but both the photo and copy clearly have 𒌆, not 𒌨).

I cannot see anything relevant in DP55 nor DP223.