### PR TITLE
LAK431 is 𒅆𒆸

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -18727,6 +18727,7 @@
 
 @sign |IGI.LAGAB|
 @oid	o0223361
+@list	LAK431
 @list	RSP069
 @useq	x12146.x121B8
 @ucun	𒅆𒆸
@@ -27379,12 +27380,6 @@
 @sign LAK416
 @list	LAK416
 @oid	o0025846
-@inote	for dcclt/ebla--check that it is not in OGSL under a different name
-@end sign
-
-@sign LAK431
-@list	LAK431
-@oid	o0025848
 @inote	for dcclt/ebla--check that it is not in OGSL under a different name
 @end sign
 


### PR DESCRIPTION
<img width="2274" height="119" alt="" src="https://github.com/user-attachments/assets/491c101f-0407-459a-8349-fb409401bb58" />

> [STH 1, 10](http://cdli.earth/P221319) [R3](http://oracc.org/epsd2/P221319.147) u. o. bei Urukag.

Not only does it look a lot like 𒅆𒆸, the sole reference is igi-nigin₂ in 𒇽𒅆𒆸.