### PR TITLE
LAK395 is 𒋙𒉣𒇬

### DIFF
--- a/00lib/osl.asl
+++ b/00lib/osl.asl
@@ -27339,9 +27339,12 @@
 @link	Wikidata Q87557307 http://www.wikidata.org/entity/Q87557307
 @end sign
 
-@sign LAK395
+@sign |ŠU₂.NUN.LAGAR|
 @list	LAK395
 @oid o0038384
+@useq	x122D9.x12263.x121EC
+@ucun	𒋙𒉣𒇬
+@ref	in SF 1, o viii 19 = http://oracc.org/dcclt/P010566.236 𒀭𒆤𒋙𒉣𒇬
 @end sign
 
 @sign LAK399


### PR DESCRIPTION
I don’t know if it should be an `@lref` instead; the all caps transliteration [KID-ŠU₂-TUR₃](http://oracc.org/dcclt/P010566.236) in dcclt doesn’t seem like a very strong signal to tell whether this is one sign or two. Either way, that DN is 𒀭𒆤𒋙𒉣𒇬, and it is the only reference given in https://eggrobin.github.io/LAK/LAK.html#395.